### PR TITLE
Add states through first antagonist encounter

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -13,7 +13,9 @@ public class GameManager : MonoBehaviour
         EndingNothing,
         OpenDoor,
         DefineAntagonist,
-        NavigateAntagonist
+        NavigateAntagonist,
+        EndingEaten,
+        Counter
     }
 
     public Animator lightingAnimator;
@@ -23,6 +25,7 @@ public class GameManager : MonoBehaviour
 
     private float stateStartTime;
     private bool lightsOn;
+    private string antagonist;
         
 
     // Start is called before the first frame update
@@ -60,6 +63,12 @@ public class GameManager : MonoBehaviour
                         else if (Input.GetKey(KeyCode.Alpha2))
                         {
                             StartTurnOffLightState();
+                            stateStartTime = Time.time;
+                            Debug.Log("Transitioning to " + currentStoryState);
+                        }
+                        else if (Input.GetKey(KeyCode.Alpha3))
+                        {
+                            StartOpenDoorState();
                             stateStartTime = Time.time;
                             Debug.Log("Transitioning to " + currentStoryState);
                         }
@@ -133,58 +142,78 @@ public class GameManager : MonoBehaviour
             // Triggered when the user chooses to go to sleep
             case StoryState.EndingNothing:
                 {
-
                     // TODO: Trigger ending and credits sequence
+                    break;
+                }
+
+            case StoryState.OpenDoor:
+                {
+                    float stateDurationSeconds = 5;
+
+                    if (elapsedSecondsInState >= stateDurationSeconds)
+                    {
+                        StartDefineAntagonistState();
+                        stateStartTime = Time.time;
+                    }
 
                     break;
                 }
 
-            // case StoryState.OpenDoor:
-            //     {
-            //         Debug.Log("Door opened in state " + currentStoryState);
+            case StoryState.DefineAntagonist:
+                {
+                    // TODO: Use UI inputs instead of key presses
+                    if (Input.GetKey(KeyCode.Alpha1))
+                    {
+                        LoadAntagonist("Dog");
+                        stateStartTime = Time.time;
+                        Debug.Log("Transitioning to " + currentStoryState);
+                    }
+                    else if (Input.GetKey(KeyCode.Alpha2))
+                    {
+                        LoadAntagonist("Hippo");
+                        stateStartTime = Time.time;
+                        Debug.Log("Transitioning to " + currentStoryState);
+                    }
+                    else if (Input.GetKey(KeyCode.Alpha3))
+                    {
+                        LoadAntagonist("Kraken");
+                        stateStartTime = Time.time;
+                        Debug.Log("Transitioning to " + currentStoryState);
+                    }
 
-            //         // TODO: Trigger audio of door opening
+                    break;
+                }
 
-            //         currentStoryState = StoryState.DefineAntagonist;
+            case StoryState.NavigateAntagonist:
+                {
+                    // TODO: Use UI inputs instead of key presses
+                    if (Input.GetKey(KeyCode.Alpha1))
+                    {
+                        currentStoryState = StoryState.EndingEaten;
+                        stateStartTime = Time.time;
+                        Debug.Log("Transitioning to " + currentStoryState);
+                    }
+                    else if (Input.GetKey(KeyCode.Alpha2))
+                    {
+                        currentStoryState = StoryState.Counter;
+                        stateStartTime = Time.time;
+                        Debug.Log("Transitioning to " + currentStoryState);
+                    }
 
-            //         break;
-            //     }
+                    break;
+                }
 
-            // case StoryState.DefineAntagonist:
-            //     {
-            //         Debug.Log("Prompting user for antagonist in state " + currentStoryState);
+            case StoryState.EndingEaten:
+                {
+                    // TODO: Trigger ending and credits sequence
+                    break;
+                }
 
-            //         // TODO: Use UI inputs instead of key presses
-            //         if (Input.GetKey(KeyCode.Alpha1))
-            //         {
-            //             LoadAntagonist("Dog");
-            //             stateStartTime = Time.time;
-            //             Debug.Log("Transitioning to " + currentStoryState);
-            //         }
-            //         else if (Input.GetKey(KeyCode.Alpha2))
-            //         {
-            //             LoadAntagonist("Hippo");
-            //             stateStartTime = Time.time;
-            //             Debug.Log("Transitioning to " + currentStoryState);
-            //         }
-            //         else if (Input.GetKey(KeyCode.Alpha3))
-            //         {
-            //             LoadAntagonist("Kraken");
-            //             stateStartTime = Time.time;
-            //             Debug.Log("Transitioning to " + currentStoryState);
-            //         }
-
-            //         currentStoryState = StoryState.NavigateAntagonist;
-
-            //         break;
-            //     }
-
-            // case StoryState.NavigateAntagonist:
-            //     {
-            //         Debug.Log("Prompting user for antagonist navigation in state " + currentStoryState);
-
-            //         break;
-            //     }
+            case StoryState.Counter:
+                {
+                    // TODO: Load counter scene, continue story
+                    break;
+                }
 
             default:
                 {
@@ -198,7 +227,7 @@ public class GameManager : MonoBehaviour
     {
         if (lightsOn)
         {
-            Debug.Log("Press 1 for walk around, 2 for lights off");
+            Debug.Log("Press 1 for walk around, 2 for lights off, 3 to open door");
         }
         else
         {
@@ -227,22 +256,37 @@ public class GameManager : MonoBehaviour
         currentStoryState = StoryState.WalkAround;
     }
 
-    // void LoadAntagonist(string antagonist)
-    // {
-    //     switch(antagonist)
-    //     {
-    //         case "Dog":
-    //             Debug.Log("Loading dog");
-    //             // TODO: Trigger loading dog
-    //             break;
-    //         case "Hippo":
-    //             Debug.Log("Loading hippo");
-    //             // TODO: Trigger loading hippo
-    //             break;
-    //         case "Kraken":
-    //             Debug.Log("Loading kraken");
-    //             // TODO: Trigger loading kraken
-    //             break;
-    //     }
-    // }
+    void StartOpenDoorState()
+    {
+        // TODO: Trigger audio of door opening
+        currentStoryState = StoryState.OpenDoor;
+    }
+
+    void StartDefineAntagonistState()
+    {
+        Debug.Log("Press 1 for dog, 2 for hippo, 3 for kraken");
+        currentStoryState = StoryState.DefineAntagonist;
+    }
+
+    void LoadAntagonist(string name)
+    {
+        switch(name)
+        {
+            case "Dog":
+                Debug.Log("Loading dog");
+                // TODO: Trigger loading dog
+                break;
+            case "Hippo":
+                Debug.Log("Loading hippo");
+                // TODO: Trigger loading hippo
+                break;
+            case "Kraken":
+                Debug.Log("Loading kraken");
+                // TODO: Trigger loading kraken
+                break;
+        }
+        antagonist = name;
+        currentStoryState = StoryState.NavigateAntagonist;
+        Debug.Log("Press 1 for approach, 2 for avoid");
+    }
 }

--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -10,7 +10,10 @@ public class GameManager : MonoBehaviour
         WalkAround,
         TurnOnLight,
         TurnOffLight,
-        GoToSleep
+        EndingNothing,
+        OpenDoor,
+        DefineAntagonist,
+        NavigateAntagonist
     }
 
     public Animator lightingAnimator;
@@ -19,6 +22,7 @@ public class GameManager : MonoBehaviour
     private StoryState currentStoryState;
 
     private float stateStartTime;
+    private bool lightsOn;
         
 
     // Start is called before the first frame update
@@ -26,6 +30,7 @@ public class GameManager : MonoBehaviour
     {
         StartBeginningState();
         stateStartTime = Time.time;
+        lightsOn = false;
     }
 
     // Update is called once per frame
@@ -44,33 +49,47 @@ public class GameManager : MonoBehaviour
                 {
 
                     // TODO: Use UI inputs instead of key presses
-                    if (Input.GetKey(KeyCode.Alpha1))
+                    if (lightsOn)
                     {
-                        StartWalkAroundState();
-                        stateStartTime = Time.time;
-                        Debug.Log("Transitioning to " + currentStoryState);
+                        if (Input.GetKey(KeyCode.Alpha1))
+                        {
+                            StartWalkAroundState();
+                            stateStartTime = Time.time;
+                            Debug.Log("Transitioning to " + currentStoryState);
+                        }
+                        else if (Input.GetKey(KeyCode.Alpha2))
+                        {
+                            StartTurnOffLightState();
+                            stateStartTime = Time.time;
+                            Debug.Log("Transitioning to " + currentStoryState);
+                        }
 
-                    }
-                    else if (Input.GetKey(KeyCode.Alpha2))
-                    {
-                        StartTurnOnLightState();
-                        stateStartTime = Time.time;
-                        Debug.Log("Transitioning to " + currentStoryState);
-                    }
-                    else if (Input.GetKey(KeyCode.Alpha3))
-                    {
-                        StartTurnOffLightState();
-                        stateStartTime = Time.time;
-                        Debug.Log("Transitioning to " + currentStoryState);
-                    }
-                    else if (Input.GetKey(KeyCode.Alpha4))
-                    {
-                        currentStoryState = StoryState.GoToSleep;
-                        stateStartTime = Time.time;
-                        Debug.Log("Transitioning to " + currentStoryState);
+                        break;
                     }
 
-                    break;
+                    else // lightsOn == false
+                    {
+                        if (Input.GetKey(KeyCode.Alpha1))
+                        {
+                            StartWalkAroundState();
+                            stateStartTime = Time.time;
+                            Debug.Log("Transitioning to " + currentStoryState);
+                        }
+                        else if (Input.GetKey(KeyCode.Alpha2))
+                        {
+                            StartTurnOnLightState();
+                            stateStartTime = Time.time;
+                            Debug.Log("Transitioning to " + currentStoryState);
+                        }
+                        else if (Input.GetKey(KeyCode.Alpha3))
+                        {
+                            currentStoryState = StoryState.EndingNothing;
+                            stateStartTime = Time.time;
+                            Debug.Log("Transitioning to " + currentStoryState);
+                        }
+
+                        break;
+                    }
                 }
                 
             case StoryState.WalkAround:
@@ -111,18 +130,61 @@ public class GameManager : MonoBehaviour
                     break;
                 }
 
-            case StoryState.GoToSleep:
+            // Triggered when the user chooses to go to sleep
+            case StoryState.EndingNothing:
                 {
-                    float stateDurationSeconds = 5;
 
-                    if (elapsedSecondsInState >= stateDurationSeconds)
-                    {
-                        StartBeginningState();
-                        stateStartTime = Time.time;
-                    }
+                    // TODO: Trigger ending and credits sequence
 
                     break;
                 }
+
+            // case StoryState.OpenDoor:
+            //     {
+            //         Debug.Log("Door opened in state " + currentStoryState);
+
+            //         // TODO: Trigger audio of door opening
+
+            //         currentStoryState = StoryState.DefineAntagonist;
+
+            //         break;
+            //     }
+
+            // case StoryState.DefineAntagonist:
+            //     {
+            //         Debug.Log("Prompting user for antagonist in state " + currentStoryState);
+
+            //         // TODO: Use UI inputs instead of key presses
+            //         if (Input.GetKey(KeyCode.Alpha1))
+            //         {
+            //             LoadAntagonist("Dog");
+            //             stateStartTime = Time.time;
+            //             Debug.Log("Transitioning to " + currentStoryState);
+            //         }
+            //         else if (Input.GetKey(KeyCode.Alpha2))
+            //         {
+            //             LoadAntagonist("Hippo");
+            //             stateStartTime = Time.time;
+            //             Debug.Log("Transitioning to " + currentStoryState);
+            //         }
+            //         else if (Input.GetKey(KeyCode.Alpha3))
+            //         {
+            //             LoadAntagonist("Kraken");
+            //             stateStartTime = Time.time;
+            //             Debug.Log("Transitioning to " + currentStoryState);
+            //         }
+
+            //         currentStoryState = StoryState.NavigateAntagonist;
+
+            //         break;
+            //     }
+
+            // case StoryState.NavigateAntagonist:
+            //     {
+            //         Debug.Log("Prompting user for antagonist navigation in state " + currentStoryState);
+
+            //         break;
+            //     }
 
             default:
                 {
@@ -134,7 +196,14 @@ public class GameManager : MonoBehaviour
 
     void StartBeginningState()
     {
-        Debug.Log("Press 1 for walk around, 2 for lights on, 3 for lights off, 4 for sleep");
+        if (lightsOn)
+        {
+            Debug.Log("Press 1 for walk around, 2 for lights off");
+        }
+        else
+        {
+            Debug.Log("Press 1 for walk around, 2 for lights on, 3 to go to sleep");
+        }
         currentStoryState = StoryState.Beginning;
     }
 
@@ -142,12 +211,14 @@ public class GameManager : MonoBehaviour
     {
         lightingAnimator.SetTrigger("playTurnOnLights");
         currentStoryState = StoryState.TurnOnLight;
+        lightsOn = true;
     }
 
     void StartTurnOffLightState()
     {
         lightingAnimator.SetTrigger("playTurnOffLights");
         currentStoryState = StoryState.TurnOffLight;
+        lightsOn = false;
     }
 
     void StartWalkAroundState()
@@ -155,4 +226,23 @@ public class GameManager : MonoBehaviour
         potatoAnimator.SetTrigger("playPotatoWalkAround");
         currentStoryState = StoryState.WalkAround;
     }
+
+    // void LoadAntagonist(string antagonist)
+    // {
+    //     switch(antagonist)
+    //     {
+    //         case "Dog":
+    //             Debug.Log("Loading dog");
+    //             // TODO: Trigger loading dog
+    //             break;
+    //         case "Hippo":
+    //             Debug.Log("Loading hippo");
+    //             // TODO: Trigger loading hippo
+    //             break;
+    //         case "Kraken":
+    //             Debug.Log("Loading kraken");
+    //             // TODO: Trigger loading kraken
+    //             break;
+    //     }
+    // }
 }


### PR DESCRIPTION
Changes:

- Modify early state logic to not allow turning on the lights when they are already on and to not allow turning off the lights when they are already off
- Additional states to end the game in the "Nothing" and "Eaten" endings
- Additional states to prompt the user for creating an antagonist and navigating the first encounter (approach vs. avoid)

There's an outstanding issue where the user input for the antagonist type is also automatically used as the input to the antagonist encounter (i.e. choosing "1" for the dog automatically chooses "1" for the approach decision).